### PR TITLE
supporting organizations do not have contributors, so skip the card-text

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -39,7 +39,7 @@ We encourage you to join our [mailing list](https://scs.sovereignit.de/mailman3/
 
 ## Supporting Organizations
 
-These organizations and people actively support the idea behind Open Operations:
+These organizations actively support the idea behind Open Operations:
 
 {% include supporting_organizations.html %}
 

--- a/_includes/supporting_organizations.html
+++ b/_includes/supporting_organizations.html
@@ -5,19 +5,6 @@
   <div class="col">
     <div class="card">
       <img src="{{organization.logo}}" class="card-img-top" alt="{{organization.name}}" class="card-img-top mx-auto d-block" style="padding: 30px; height: 150px; width: 300px; object-fit: contain; object-position: center;" >
-      <div class="card-body">
-        <p class="card-text">
-          <ul class="list-group list-group-flush">
-          {% assign contributors_sorted = organization.contributors | sort_natural: 'role' %}
-          {% for contributor in contributors_sorted %}
-            <li class="list-group-item" style="line-height: 1.2;">
-              <small>{{contributor.name}}</small><br/>
-              <small class="text-muted"><em>{{contributor.role}}</em></small>
-            </li>
-          {% endfor %}
-          </ul>
-        </p>
-      </div>
     </div>
   </div>
 {% endfor %}


### PR DESCRIPTION
* since the list of supporting organizations only have the fields name, logo and url, we can skip the extra div for the card-body